### PR TITLE
voice: P1 wave — sub-page polish, CTA convergence, lead form, nav, 404

### DIFF
--- a/src/app/foundry/page.tsx
+++ b/src/app/foundry/page.tsx
@@ -210,7 +210,7 @@ export default function FoundryPage() {
     <>
       {/* Hero */}
       <HeroSection
-        byline="RevenuePoint Foundry"
+        byline="Foundry · Fully managed data orchestration"
         heading={
           <>
             Your data, connected. Agents that <em>take action</em>. Fully managed.
@@ -469,7 +469,7 @@ export default function FoundryPage() {
           <SectionHeader
             eyebrow="AGENTS"
             heading="Your morning briefing. Automatically."
-            body="Foundry agents watch your systems overnight, process inbound work, run scheduled reports, and respond to events in seconds. By the time your team logs in, the Home Feed already has the answers."
+            body="Foundry agents watch your systems continuously, process inbound work, run scheduled reports, and respond to events in seconds. By the time your team logs in, the Home Feed already has the answers — every action logged, every change reversible."
             align="center"
           />
           <AgentTypeStrip />
@@ -540,7 +540,7 @@ export default function FoundryPage() {
           <SectionHeader
             eyebrow="OTTO"
             heading="Ask Otto anything."
-            body="Otto is your AI analyst, plugged into every business object in Blueprint. It reasons, cites, renders — and proposes the next action. Pick a prompt to see it run."
+            body="Otto is your AI analyst, plugged into every business object in Blueprint. Reasons, cites, renders — and proposes the next best action, scoped and reviewer-approved before it executes. Pick a prompt to see it run."
             align="center"
           />
           <ProductViewport
@@ -651,11 +651,11 @@ export default function FoundryPage() {
         eyebrow="Schedule a working session"
         heading={
           <>
-            Ready to see Foundry <em>in action</em>?
+            See Foundry connected to <em>systems like yours</em>.
           </>
         }
-        body="Schedule a personalized demo. We'll show you what Foundry looks like connected to systems just like yours."
-        cta={{ label: 'Schedule a demo', href: SCHEDULE_URL }}
+        body="Schedule a 30-minute demo. We'll show you Foundry connected to systems like the ones your business runs on, with sample data the buyer at your role would actually look at."
+        cta={{ label: 'Schedule a 30-minute demo', href: SCHEDULE_URL }}
       />
     </>
   );

--- a/src/app/foundry/pricing/page.tsx
+++ b/src/app/foundry/pricing/page.tsx
@@ -66,7 +66,7 @@ export default function FoundryPricingPage() {
                 Simple, predictable pricing. <em>No surprises</em>.
               </>
             }
-            body="Flat monthly managed service pricing. No usage fees, no per-seat charges, no consumption bills. You always know what Foundry costs."
+            body="Flat monthly managed-service pricing. No usage fees, no per-seat charges. You always know what Foundry costs next month."
             align="left"
           />
 
@@ -125,9 +125,9 @@ export default function FoundryPricingPage() {
           <div className="max-w-3xl mx-auto mt-10 text-center">
             <p className="text-sm text-ink leading-relaxed">
               One-time implementation fee of{' '}
-              <span className="font-semibold text-navy">$8,000–$60,000</span> depending on source
-              system count and data complexity. Scoped during a paid discovery engagement before you
-              commit to a monthly plan.
+              <span className="font-semibold text-navy">$8,000–$60,000</span> — scoped to your
+              source-system count and data complexity during a paid discovery engagement, before
+              you commit to a monthly plan.
             </p>
           </div>
         </div>

--- a/src/app/gateway/connectors/page.tsx
+++ b/src/app/gateway/connectors/page.tsx
@@ -116,7 +116,7 @@ export default function GatewayConnectorsPage() {
         }
         body="Salesforce and SAP ship today. NetSuite, Microsoft Dynamics, and QuickBooks are on the roadmap. The Custom REST/GraphQL adapter covers everything else with an API. Each connector is a typed adapter; auth, retries, and per-tenant secrets are handled in one place."
         ctas={[
-          { label: 'Schedule a walkthrough', href: SCHEDULE_URL, variant: 'primary' },
+          { label: 'Schedule a Gateway demo', href: SCHEDULE_URL, variant: 'primary' },
           { label: 'Back to Gateway', href: '/gateway/', variant: 'secondary' },
         ]}
       />
@@ -171,7 +171,7 @@ export default function GatewayConnectorsPage() {
             Custom connectors are a <em>2–4 week</em> build.
           </h2>
           <p className="mt-5 text-base leading-[1.65] text-inkSoft max-w-prose">
-            Every connector implements the same interface. RevenuePoint engineers build the named connector; once shipped, it becomes part of the Gateway product so other customers can use it (without touching your tenants or your data).
+            Every connector implements the same interface. RevenuePoint engineers build the new connector; once shipped, it becomes part of the Gateway product — available to every customer without touching your tenants or your data.
           </p>
           <pre className="mt-6 border border-rule bg-ink text-paper p-5 text-[12.5px] font-mono leading-relaxed overflow-x-auto whitespace-pre">
 {`export interface GatewayConnector<T = unknown> {

--- a/src/app/gateway/page.tsx
+++ b/src/app/gateway/page.tsx
@@ -93,7 +93,7 @@ export default function GatewayPage() {
     <TenantProvider>
       {/* 1 — Hero */}
       <HeroSection
-        byline="RevenuePoint Gateway"
+        byline="Gateway · Multi-tenant portals"
         heading={
           <>
             Multi-tenant portals. Connected to your CRM and ERP. <em>Fully managed</em>.
@@ -102,7 +102,7 @@ export default function GatewayPage() {
         body="Gateway gives every customer, partner, dealer, or location their own branded portal — wired into your CRM, ERP, and accounting. Magic-link login, code-defined access rules, tenant-level data isolation. Fully managed by RevenuePoint."
         sidenote="Magic-link auth · code-defined rules · tenant-level isolation."
         ctas={[
-          { label: 'Schedule a walkthrough', href: SCHEDULE_URL, variant: 'primary' },
+          { label: 'Schedule a Gateway demo', href: SCHEDULE_URL, variant: 'primary' },
           { label: 'View pricing', href: '/gateway/pricing/', variant: 'secondary' },
         ]}
         rightSlot={<TenantSwitcherHero />}
@@ -224,8 +224,12 @@ export default function GatewayPage() {
         <div className="max-w-7xl mx-auto px-4">
           <SectionHeader
             eyebrow="TENANTS"
-            heading="Each tenant, isolated by design. Each tenant, branded their way."
-            body="Pick a tenant. Watch the subdomain change, the connection swap, the access rule rewrite, the brand color follow. One Gateway deployment, every tenant on its own everything."
+            heading={
+              <>
+                Six portals. <em>One framework</em>.
+              </>
+            }
+            body="Pick a tenant. Watch the subdomain change, the connection swap, the access rule rewrite, the brand color follow. Each tenant, isolated by design. Each tenant, branded their way. One Gateway deployment, every tenant on its own everything."
             align="center"
             light
           />
@@ -339,7 +343,7 @@ export default function GatewayPage() {
         <div className="max-w-7xl mx-auto px-4">
           <SectionHeader
             heading="The portal layer for companies that outgrew Salesforce Sites."
-            body="Most portal options are tied to one CRM, share data underneath, or take six months to build. Gateway is the only one fully managed, multi-tenant by design, and not locked to a single source system."
+            body="Most portal options are tied to one CRM, share data underneath, or take six months to build. Gateway is fully managed by RevenuePoint, multi-tenant by design, connects to every CRM and ERP you run on, and ships under flat per-tenant pricing."
           />
           <ComparisonTable
             headers={[

--- a/src/app/gateway/pricing/page.tsx
+++ b/src/app/gateway/pricing/page.tsx
@@ -33,7 +33,7 @@ export default function GatewayPricingPage() {
         body="Per-tenant, per-month pricing. Hosting, magic-link auth, the connector to your CRM or ERP, per-tenant theming, audit log, and your single point of contact at RevenuePoint are all included. No surprise consumption bills. No per-seat add-ons."
         sidenote="No surprise consumption bills · no per-seat add-ons."
         ctas={[
-          { label: 'Schedule a walkthrough', href: SCHEDULE_URL, variant: 'primary' },
+          { label: 'Schedule a Gateway demo', href: SCHEDULE_URL, variant: 'primary' },
           { label: 'Back to Gateway', href: '/gateway/', variant: 'secondary' },
         ]}
       />
@@ -63,7 +63,7 @@ export default function GatewayPricingPage() {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 border border-crimson text-crimson font-serif italic text-[15px] px-5 py-2 hover:bg-paper transition-colors"
               >
-                Schedule a walkthrough <span aria-hidden="true">→</span>
+                Schedule a Gateway demo <span aria-hidden="true">→</span>
               </a>
               <Link
                 href="/gateway/"

--- a/src/app/gateway/use-cases/page.tsx
+++ b/src/app/gateway/use-cases/page.tsx
@@ -30,7 +30,7 @@ export default function GatewayUseCasesPage() {
         }
         body="The portals our customers run on Gateway today. Each archetype is a different audience and a different access rule — but all built on the same Gateway deployment, the same connector model, the same managed stack."
         ctas={[
-          { label: 'Schedule a walkthrough', href: SCHEDULE_URL, variant: 'primary' },
+          { label: 'Schedule a Gateway demo', href: SCHEDULE_URL, variant: 'primary' },
           { label: 'Back to Gateway', href: '/gateway/', variant: 'secondary' },
         ]}
       />
@@ -114,9 +114,9 @@ export default function GatewayUseCasesPage() {
       </section>
 
       <CTABanner
-        heading="Talk through your tenant model with an architect."
-        body="Thirty minutes. We sketch the access rule, name the connectors, list the views, and quote a path to live."
-        cta={{ label: 'Schedule a walkthrough →', href: SCHEDULE_URL }}
+        heading="Sketch your tenant model with a Gateway architect."
+        body="Thirty minutes. We name the access rule, list the connectors and views, and quote a path to live."
+        cta={{ label: 'Schedule a Gateway demo', href: SCHEDULE_URL }}
       />
     </>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,31 @@
+import { buildMetadata } from '@/lib/metadata';
+import { Button } from '@/components/ui/Button';
+
+export const metadata = buildMetadata({
+  title: 'Page not found',
+  description: 'The page you were looking for does not exist on revenuepoint.com.',
+  path: '/404/',
+});
+
+export default function NotFound() {
+  return (
+    <section className="bg-paper py-24 lg:py-32">
+      <div className="max-w-2xl mx-auto px-6 lg:px-8 text-center">
+        <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-mute justify-center inline-flex items-center gap-2">
+          <span className="h-px w-8 bg-rust" /> 404 · page not found
+        </p>
+        <h1 className="mt-6 text-d1 font-serif font-semibold text-ink">
+          That page <em>does not exist</em>.
+        </h1>
+        <p className="mt-6 text-lede text-inkSoft leading-[1.65] max-w-prose mx-auto">
+          The link is wrong, the page moved, or it never existed. Try one of these instead.
+        </p>
+        <div className="mt-10 flex flex-wrap gap-4 justify-center">
+          <Button variant="primary" href="/">Go to homepage</Button>
+          <Button variant="secondary" href="/foundry/">Explore Foundry</Button>
+          <Button variant="secondary" href="/contact/">Get in touch</Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/npsp-middleware/page.tsx
+++ b/src/app/npsp-middleware/page.tsx
@@ -223,7 +223,7 @@ export default function NpspMiddlewarePage() {
                 href={NPSP_CONTACT_HREF}
                 className="inline-flex items-center px-6 py-3 rounded-sm bg-crimson text-white text-sm font-semibold hover:bg-crimsonDeep transition-colors"
               >
-                Schedule a walkthrough →
+                Schedule a newsroom consultation →
               </Link>
               <a
                 href={NPSP_GITHUB_URL}
@@ -274,7 +274,7 @@ export default function NpspMiddlewarePage() {
       <CTABanner
         heading="Ready to see it running?"
         body="Thirty minutes with a RevenuePoint architect. We walk the donor-facing checkout, the member portal, the Salesforce sync — and scope a managed rollout if it fits."
-        cta={{ label: 'Schedule a walkthrough →', href: SCHEDULE_URL }}
+        cta={{ label: 'Schedule a newsroom consultation', href: SCHEDULE_URL }}
       />
 
       {/* Lead form */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,9 +50,9 @@ export default function Home() {
                 Built on a decade of implementing and managing enterprise systems end-to-end.
               </p>
               <p className="text-[0.875rem] text-inkSoft leading-relaxed">
-                Our broad range of experience across CRM, ERP, accounting, data infrastructure,
-                and AI allows us to connect systems to drive faster decisions and reduce manual
-                reconciliation and busywork.
+                A decade of implementing and managing the systems growing businesses run on —
+                Salesforce, SAP, accounting platforms, data infrastructure, and the AI layer
+                that connects them.
               </p>
             </div>
             <ul className="divide-y divide-rule">
@@ -319,7 +319,7 @@ export default function Home() {
               </>
             }
             align="left"
-            body="A repeatable four-step engagement model, our wide range of experience across enterprise platforms, and an agentic-assisted delivery process allow us to deliver results in as little as half the typical implementation timeline."
+            body="A repeatable four-step engagement model, 60+ Salesforce certifications across every cloud you might run on, and an AI-assisted delivery process that compresses the work — not the testing — into half the typical implementation timeline."
           />
           <StepList
             steps={[
@@ -333,7 +333,7 @@ export default function Home() {
                 number: 2,
                 title: 'Implementation',
                 description:
-                  'Certified admins configure and deploy to industry best practices, built around your actual processes.',
+                  'Certified admins configure and deploy to the published platform best practices for your industry — Salesforce CRM patterns, SAP MRP and posting-period rules, Foundry semantic-layer conventions — built around your actual processes.',
               },
               {
                 number: 3,
@@ -357,12 +357,8 @@ export default function Home() {
         <div className="max-w-3xl mx-auto px-6 lg:px-8">
           <SectionHeader
             eyebrow="Get in touch"
-            heading={
-              <>
-                Ready to find out if we&rsquo;re a <em>good fit</em>?
-              </>
-            }
-            body="We review every submission personally and respond within one business day. Tell us about your business and what you're trying to solve."
+            heading="Schedule a 30-minute scoping call."
+            body="We review every submission personally and respond within one business day. Tell us what you're trying to solve, and we'll come back with a path forward — or tell you we're not the right partner for it."
             align="left"
           />
           <LeadForm interest="General" />

--- a/src/app/research/intelligence-reports/page.tsx
+++ b/src/app/research/intelligence-reports/page.tsx
@@ -168,7 +168,7 @@ export default function IntelligenceReportsPage() {
                   Foundry Prism
                 </p>
                 <p className="text-sm text-inkSoft leading-relaxed">
-                  Templated, scheduled, internal-data reports written overnight from your warehouse. Best for operational reporting at a regular cadence.
+                  Templated, internal-data reports generated on demand from your warehouse. Best for operational reporting on the cadence you set.
                 </p>
               </div>
               <div>
@@ -205,13 +205,13 @@ export default function IntelligenceReportsPage() {
       <section className="bg-snow py-section">
         <div className="max-w-3xl mx-auto px-6 lg:px-8">
           <SectionHeader
-            eyebrow="Get in touch"
+            eyebrow="Commission a report"
             heading={
               <>
                 Tell us what you need to know — <em>about whom</em>.
               </>
             }
-            body="A scoping call confirms fit, sources, cadence, and timeline. We will price the engagement before any work begins."
+            body="A scoping call confirms fit, sources, cadence, and timeline. We price the engagement before any work begins — fixed fee per report, starting at $6,800."
             align="left"
           />
           <LeadForm interest="Intelligence Reports" id="lead-form" />

--- a/src/app/salesforce/health-check/page.tsx
+++ b/src/app/salesforce/health-check/page.tsx
@@ -39,9 +39,9 @@ export default function CrmHealthCheckPage() {
       <section id="request" className="bg-white border-t border-rule">
         <div className="max-w-3xl mx-auto px-4 py-16 lg:py-20">
           <SectionHeader
-            eyebrow="Start with a 30-minute scoping call"
+            eyebrow="Schedule a health check"
             heading="Request a CRM Health Check"
-            body="Tell us a bit about your stack. We will confirm fit, scope the assessment, and send a statement of work."
+            body="Tell us about your stack. We confirm fit, scope the assessment, and send a statement of work."
           />
           <LeadForm interest="CRM Health Check" />
         </div>

--- a/src/app/salesforce/implementations/page.tsx
+++ b/src/app/salesforce/implementations/page.tsx
@@ -142,13 +142,13 @@ const foundryPillars = [
   },
   {
     eyebrow: '02 · Illuminate',
-    headline: 'Live dashboards. Overnight AI analysis.',
-    body: 'Lens dashboards for every role and Prism reports written overnight so leadership has answers by 8 AM.',
+    headline: 'Live dashboards. AI analysis on demand.',
+    body: 'Lens dashboards for every role and Prism reports on demand — leadership gets the answers when they ask, not on a schedule the warehouse decides.',
   },
   {
     eyebrow: '03 · Act',
-    headline: 'Agents watch, decide, and execute.',
-    body: 'Agents and Otto take action across Salesforce and the rest of your stack — fully auditable, fully managed.',
+    headline: 'Agents propose. Reviewers approve. Foundry executes.',
+    body: 'Agents and Otto propose plans across Salesforce and the rest of your stack — every action logged, attributed, reversible, and only on reviewer approval. Fully managed by RevenuePoint.',
   },
 ];
 
@@ -386,9 +386,10 @@ export default function SalesforceImplementationsPage() {
             </h2>
             <p className="mt-4 text-base leading-relaxed text-gray-300">
               A good implementation gives you a clean foundation. Foundry is what comes next —
-              connecting the rest of your stack (ERP, accounting, telephony, marketing), delivering
-              live dashboards and overnight AI reports, and running agents that take action across
-              every system. Fully managed by RevenuePoint.
+              connecting the rest of your stack (ERP, accounting, telephony, marketing) into your
+              single source of truth, fully managed by RevenuePoint, and delivering live
+              dashboards, AI analysis on demand, and agents that propose, get approved, and
+              execute across your systems.
             </p>
           </div>
 

--- a/src/app/salesforce/managed-services/page.tsx
+++ b/src/app/salesforce/managed-services/page.tsx
@@ -28,13 +28,13 @@ const foundryPillars = [
   },
   {
     eyebrow: '02 · Illuminate',
-    headline: 'Live dashboards. Overnight AI analysis.',
-    body: 'Lens dashboards for every role and Prism reports written overnight so leadership has answers by 8 AM.',
+    headline: 'Live dashboards. AI analysis on demand.',
+    body: 'Lens dashboards for every role and Prism reports on demand — leadership gets the answers when they ask, not on a schedule the warehouse decides.',
   },
   {
     eyebrow: '03 · Act',
-    headline: 'Agents watch, decide, and execute.',
-    body: 'Agents and Otto take action across Salesforce and the rest of your stack — fully auditable, fully managed.',
+    headline: 'Agents propose. Reviewers approve. Foundry executes.',
+    body: 'Agents and Otto propose plans across Salesforce and the rest of your stack — every action logged, attributed, reversible, and only on reviewer approval. Fully managed by RevenuePoint.',
   },
 ];
 
@@ -207,7 +207,7 @@ export default function SalesforceManagedServicesPage() {
               Foundry sits on top of a <em className="text-crimson">clean</em> Salesforce.
             </h2>
             <p className="mt-4 text-lede leading-[1.65] text-paper/80 max-w-prose">
-              Once your Salesforce stays clean — month after month — Foundry connects the rest of your stack and delivers live dashboards, AI reports, and agents that take action. Fully managed by RevenuePoint.
+              Once your Salesforce stays clean — month after month — Foundry connects the rest of your stack and delivers live dashboards, AI analysis on demand, and agents that propose, get approved, and execute across your systems. Fully managed by RevenuePoint.
             </p>
           </div>
 

--- a/src/app/salesforce/managed-services/pricing/page.tsx
+++ b/src/app/salesforce/managed-services/pricing/page.tsx
@@ -80,9 +80,9 @@ export default function SalesforceManagedServicesPricingPage() {
               price="Custom"
               description="For organizations with unique needs. Get in touch and we'll scope a plan specific to your instance."
               features={[
-                'Tailored to your specific Salesforce instance',
+                'Tailored to your Salesforce instance',
                 'Custom hours and scope',
-                'Dedicated team configuration',
+                'Team scaled to your requirements — your single point of contact stays constant',
               ]}
               cta={{ label: 'Schedule a custom-plan scoping call', href: '/contact/?interest=Salesforce' }}
             />

--- a/src/app/salesforce/page.tsx
+++ b/src/app/salesforce/page.tsx
@@ -29,8 +29,8 @@ const foundryPillars = [
   },
   {
     eyebrow: '03 · Act',
-    headline: 'Agents watch, decide, and execute.',
-    body: 'Agents and Otto take action across Salesforce and the rest of your stack — fully auditable, fully managed.',
+    headline: 'Agents propose. Reviewers approve. Foundry executes.',
+    body: 'Agents and Otto propose plans across Salesforce and the rest of your stack — every action logged, attributed, reversible, and only on reviewer approval. Fully managed by RevenuePoint.',
   },
 ];
 
@@ -89,9 +89,13 @@ export default function SalesforcePage() {
       <section className="bg-white py-16 lg:py-24">
         <div className="max-w-7xl mx-auto px-4">
           <SectionHeader
-            eyebrow="Industries we know"
-            heading="Ten industries. Ten clean record pages."
-            body="Salesforce looks different in a specialty pharmacy than it does in a distributor or a nonprofit. We build Lightning record pages that work the way your industry actually runs."
+            eyebrow="Industries we configure to"
+            heading={
+              <>
+                Ten industries. <em>Ten Lightning record pages</em>.
+              </>
+            }
+            body="Salesforce looks different in a specialty pharmacy than it does in a distributor or a nonprofit. We build Lightning record pages — the right custom components, the integrations to the systems you already use, and the layout the user actually needs — for the way your industry runs."
           />
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {industryPageList.map((industry) => (
@@ -142,7 +146,7 @@ export default function SalesforcePage() {
               Foundry sits on top of a <em className="text-crimson">clean</em> Salesforce.
             </h2>
             <p className="mt-4 text-lede leading-[1.65] text-paper/80 max-w-prose">
-              Once your Salesforce is clean, Foundry connects the rest of your stack — ERP, accounting, telephony, marketing — and delivers live dashboards, AI reports, and agents that take action. Fully managed by RevenuePoint.
+              Once your Salesforce is clean, Foundry connects the rest of your stack — ERP, accounting, telephony, marketing — into your single source of truth, fully managed by RevenuePoint. Live dashboards. AI analysis on demand. Agents that propose, get approved, and execute across your systems.
             </p>
           </div>
 

--- a/src/app/salesforce/training/page.tsx
+++ b/src/app/salesforce/training/page.tsx
@@ -130,7 +130,7 @@ export default function SalesforceTrainingPage() {
         <div className="max-w-3xl mx-auto px-4">
           <SectionHeader
             heading="Tell us about your Salesforce training and Playbook needs"
-            body="We will confirm fit, scope the engagement, and send a statement of work."
+            body="We confirm fit, scope the engagement, and send a statement of work — typically within two business days."
           />
           <LeadForm interest="Salesforce Training" id="lead-form" />
         </div>

--- a/src/app/sap/page.tsx
+++ b/src/app/sap/page.tsx
@@ -123,13 +123,13 @@ const foundryPillars = [
   },
   {
     eyebrow: '02 · Illuminate',
-    headline: 'Live dashboards. Overnight AI analysis.',
-    body: 'Lens dashboards for every role and Prism reports written overnight so leadership has answers by 8 AM.',
+    headline: 'Live dashboards. AI analysis on demand.',
+    body: 'Lens dashboards for every role and Prism reports on demand — leadership gets the answers when they ask, not on a schedule the warehouse decides.',
   },
   {
     eyebrow: '03 · Act',
-    headline: 'Agents watch, decide, and execute.',
-    body: 'Agents and Otto take action across SAP and the rest of your stack — fully auditable, fully managed.',
+    headline: 'Agents propose. Reviewers approve. Foundry executes.',
+    body: 'Agents and Otto propose plans across SAP and the rest of your stack — every action logged, attributed, reversible, and only on reviewer approval. Fully managed by RevenuePoint.',
   },
 ];
 
@@ -172,7 +172,7 @@ export default function SAPPage() {
         <div className="max-w-7xl mx-auto px-4">
           <SectionHeader
             eyebrow="How it works"
-            heading="Named team. Hours each month. Two-week sprints. Month-to-month."
+            heading="Single point of contact. Hours each month. Two-week sprints. Month-to-month."
             body="The engagement model is boring on purpose. You should know who is doing your work, how many hours you have, when the next change is going out, and that you can walk away if the work is not landing."
           />
           <StepList steps={engagementSteps} />

--- a/src/app/sap/pricing/page.tsx
+++ b/src/app/sap/pricing/page.tsx
@@ -43,7 +43,7 @@ export default function SAPPricingPage() {
               ))}
             </ol>
             <div className="mt-8">
-              <Button href="/contact/?interest=SAP">Get a custom quote</Button>
+              <Button href="/contact/?interest=SAP">Schedule an SAP scoping call</Button>
             </div>
           </div>
         </div>
@@ -51,7 +51,7 @@ export default function SAPPricingPage() {
 
       <section className="bg-cream border-t border-ruleSoft py-section">
         <div className="max-w-3xl mx-auto px-6 lg:px-8">
-          <SectionHeader heading="Tell us about your SAP requirements." />
+          <SectionHeader heading="Tell us about your SAP environment — modules, users, integrations." />
           <LeadForm interest="SAP" />
         </div>
       </section>

--- a/src/components/industries/NpspMiddlewareSection.tsx
+++ b/src/components/industries/NpspMiddlewareSection.tsx
@@ -140,7 +140,7 @@ export function NpspMiddlewareSection() {
                 href={NPSP_CONTACT_HREF}
                 className="inline-flex items-center px-5 py-2.5 rounded-sm bg-crimson text-white text-sm font-semibold hover:bg-crimsonDeep transition-colors"
               >
-                Schedule a walkthrough →
+                Schedule a newsroom consultation →
               </Link>
               <Link
                 href="/npsp-middleware/"

--- a/src/components/industries/PackagingTiers.tsx
+++ b/src/components/industries/PackagingTiers.tsx
@@ -59,7 +59,7 @@ export function PackagingTiers({
                       featured ? 'text-crimson hover:text-crimsonDeep' : 'text-ink hover:text-navySoft'
                     }`}
                   >
-                    Book a working session <span aria-hidden="true">→</span>
+                    Schedule a Salesforce scoping call <span aria-hidden="true">→</span>
                   </Link>
                 )}
               </div>

--- a/src/components/ui/LeadForm.tsx
+++ b/src/components/ui/LeadForm.tsx
@@ -193,7 +193,7 @@ export function LeadForm({ interest, id }: LeadFormProps) {
         type="submit"
         className="md:col-span-2 inline-flex items-center justify-center gap-2 border border-crimson text-crimson font-serif italic text-[15px] py-3 px-8 hover:bg-crimsonTint transition-colors"
       >
-        Get in touch <span aria-hidden="true">→</span>
+        Send to RevenuePoint <span aria-hidden="true">→</span>
       </button>
     </form>
   );

--- a/src/data/salesforceConsulting.ts
+++ b/src/data/salesforceConsulting.ts
@@ -116,7 +116,7 @@ export const consultingProducts: ConsultingProduct[] = [
     id: 'administration',
     name: 'Salesforce Administration',
     overview:
-      'Most organizations implement Salesforce correctly and then let it drift. A named RevenuePoint administrator prevents that. We audit, optimize, and evolve your instance month to month. Fully managed by RevenuePoint.',
+      'Most organizations implement Salesforce correctly and then let it drift. Fully managed by RevenuePoint prevents that — your single point of contact and a project manager audit, optimize, and evolve your instance month to month, with a team that knows your org behind them.',
     whatWeDo: [
       'User provisioning, permissions, and license management',
       'Release readiness and three-times-yearly platform upgrades',

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -24,7 +24,7 @@ export const navItems: NavItem[] = [
     href: '/salesforce/',
     groups: [
       {
-        heading: 'Customer Relationship Management',
+        heading: 'CRM',
         links: [
           { label: 'Salesforce Consulting', href: '/salesforce/' },
           { label: 'Salesforce Implementations', href: '/salesforce/implementations/' },
@@ -71,7 +71,7 @@ export const navItems: NavItem[] = [
     children: [
       { label: 'Platform Overview', href: '/foundry/' },
       { label: 'Pricing', href: '/foundry/pricing/' },
-      { label: 'Request a Demo', href: '/contact/?interest=Foundry' },
+      { label: 'Schedule a 30-minute demo', href: '/contact/?interest=Foundry' },
     ],
   },
   {
@@ -83,7 +83,7 @@ export const navItems: NavItem[] = [
       { label: 'Use Cases', href: '/gateway/use-cases/' },
       { label: 'Connectors', href: '/gateway/connectors/' },
       { label: 'Pricing', href: '/gateway/pricing/' },
-      { label: 'Request a Demo', href: '/contact/?interest=Gateway' },
+      { label: 'Schedule a Gateway demo', href: '/contact/?interest=Gateway' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Phase 2 PR 2 of 3 (P1 wave) for revenuepoint/revenuepoint.com#10. Builds on #13 (P0 wave, merged in 1f9deac).

Applies ~46 P1 changes from `brand/site-alignment/implementation-checklist.md`. **23 files · 112 insertions · 76 deletions · 1 new file (`src/app/not-found.tsx`).**

## What changed

- **Homepage** — track-record body (drop *broad range of experience* filler), how-we-work header (60+ certs receipt + AI-assisted compression claim), Step 2 (industry-specific platform best practices), lead-form heading + body (question → declarative; brand commitment-and-honesty close).
- **Foundry** — hero byline (*RevenuePoint Foundry* → *Foundry · Fully managed data orchestration*); agents body (overnight → continuously + audit pairing); Otto chat body (locked *next best action* + *scoped, reviewer-approved before it executes*); demo CTA banner (locked declarative + *Schedule a 30-minute demo*).
- **Salesforce hub** — Foundry pillar 3 *Act* rewrite (locked plan-and-action vocabulary), Foundry teaser body (SSOT pairing + on-demand + propose/approve/execute), consulting data file managed-admin description (*named admin* → *Fully managed by RevenuePoint prevents that*), Industries section heading (italicized noun + operationally specific body).
- **SAP** — *How it works* heading (*Named team* → *Single point of contact*), Foundry-pillar block (Illuminate + Act).
- **Gateway** — hero byline (*RevenuePoint Gateway* → *Gateway · Multi-tenant portals*), comparison-table body (drop *the only one*; enumerate four specific differentiators), Tenants section heading (*Six portals. One framework.* — locked tagline).
- **Intelligence Reports** — Foundry Prism comparison block (*scheduled… written overnight* → *generated on demand* / *cadence you set*), lead-form section (eyebrow *Get in touch* → *Commission a report*; price added: *fixed fee per report, starting at $6,800*).
- **Foundry pricing** — hero subhead (drop *no consumption bills*; add *what Foundry costs next month*), implementation-fee scope sentence (single em-dash sentence).
- **Salesforce managed services** — Foundry-pillar block + Foundry teaser body (cascade).
- **Salesforce managed services pricing** — Custom Plan description (drop *Dedicated team configuration*; substitute *Team scaled to your requirements — your single point of contact stays constant*).
- **Salesforce implementations** — Foundry-pillar block + Foundry teaser body (SSOT pairing + plan-and-action).
- **Salesforce health check** — lead-form section eyebrow (*Start with a 30-minute scoping call* → *Schedule a health check*); body (present tense, drop *a bit about*).
- **Salesforce training** — lead-form body (present tense + *typically within two business days* receipt).
- **SAP pricing** — CTA alignment (*Get a custom quote* → *Schedule an SAP scoping call*); lead-form heading (*Tell us about your SAP requirements.* → *Tell us about your SAP environment — modules, users, integrations.*).
- **Gateway use-cases** — primary CTA (*Schedule a walkthrough* → *Schedule a Gateway demo*) + final CTA banner (declarative *Sketch your tenant model with a Gateway architect.* + locked CTA).
- **Gateway connectors** — build-your-own body (*the named connector* → *the new connector*); final CTA convergence.
- **PackagingTiers** (industries shared component) — tier card CTA convergence (*Book a working session* → *Schedule a Salesforce scoping call*).
- **Microcopy** — site-wide convergence:
  - **MICRO-CTA-02**: *Schedule a walkthrough* → *Schedule a Gateway demo* / *Schedule a newsroom consultation* across 6 locations (gateway hub, pricing, use-cases, connectors; npsp-middleware page + section).
  - **MICRO-FORM-01**: lead-form submit button (*Get in touch* → *Send to RevenuePoint*).
  - **MICRO-NAV-01**: nav submenu heading (*Customer Relationship Management* → *CRM* per household-acronym protocol).
  - **MICRO-NAV-03**: Foundry/Gateway dropdowns (*Request a Demo* → *Schedule a 30-minute demo* / *Schedule a Gateway demo* per locked CTA table).
- **404-01**: new `src/app/not-found.tsx` — Next.js App Router not-found surface; mirrors `thank-you` page structure (status pill, italicized-noun h1, lede body, three-CTA recovery stack).

## Test plan

- [x] **TypeScript typecheck** passes (`npx tsc --noEmit` returns 0)
- [x] **Regex banlist** clean across `src/app/`, `src/components/`, `src/data/`, `src/lib/` — 0 in-scope hits for: *named [role]*, *dedicated [role]*, *white-glove*, *mid-market*, *offshore*, *live in 6 weeks*, *no data engineers required*, *vet every*, *Get [Ss]tarted*, *Talk to us*, *Schedule a walkthrough*. (Italicized *Talk to us* headline on `/gateway/pricing/` retained — in-context direct invitation, not banned CTA.)
- [ ] **Build** — `npm run build` (run before merge)
- [ ] **Visual QA at `npm run dev`** — walk every touched page, especially the new italicized headlines on Foundry CTA banner, IR Foundry-Prism block, Gateway Tenants section, and the Salesforce Industries grid heading
- [ ] **404 page** — visit any non-existent URL (e.g. `/foo/`) to confirm new not-found surface renders
- [ ] **Lead form** — confirm submit button reads *Send to RevenuePoint →* across every form on the site
- [ ] **Nav** — confirm `Services` dropdown shows *CRM* heading; `Foundry`/`Gateway` dropdowns show locked CTAs

## Out of scope (PR 3 — P2 wave)

- HOME-21 (*What we do* eyebrow body — *Implementation in weeks* → *Two-week sprints to ship the work*)
- FNDY-11 (Comparison-table body ThoughtSpot phrasing tightening)
- GTWY-05 (Implementation section heading reframe)
- SF-TR-04 (PlaybookWalkthrough component review)
- MICRO-FOOTER-03 (footer address cosmetic — add *Three World Financial Center* line)
- BRAND-meta (homepage explicit `export const metadata` add)

Insights blog post bodies remain out of scope for the launch — Phase 4 follow-up issue.

Refs #10.