### PR TITLE
voice: P2 wave — homepage cadence, Foundry comparison, Gateway go-live, footer address

### DIFF
--- a/src/app/foundry/page.tsx
+++ b/src/app/foundry/page.tsx
@@ -602,7 +602,7 @@ export default function FoundryPage() {
                 The only platform that orchestrates the <em>full loop</em>.
               </>
             }
-            body="No other platform in this category manages pipeline, warehouse, intelligence, agents, and action execution as a single service. ThoughtSpot costs $140,000/year and still requires a data engineering team to run it. Foundry starts at $2,500/month — fully managed by RevenuePoint."
+            body="No other platform in this category manages pipeline, warehouse, intelligence, agents, and action execution as a single service. ThoughtSpot lists at $140,000 a year and still requires a data engineering team to run it. Foundry starts at $2,500 a month — fully managed by RevenuePoint."
             align="left"
           />
           <ComparisonTable

--- a/src/app/gateway/page.tsx
+++ b/src/app/gateway/page.tsx
@@ -374,7 +374,13 @@ export default function GatewayPage() {
       {/* 11 — Implementation */}
       <section className="bg-cream py-16 lg:py-24">
         <div className="max-w-7xl mx-auto px-4">
-          <SectionHeader heading="Live in 4 weeks. Here's how." />
+          <SectionHeader
+            heading={
+              <>
+                <em>Four-week</em> go-live. Here&rsquo;s how.
+              </>
+            }
+          />
           <StepList
             steps={[
               {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -127,7 +127,7 @@ export default function Home() {
               </>
             }
             align="left"
-            body="Implementation in weeks. Operations under a single engagement. No long-term contract. The same model on every line."
+            body="Two-week sprints to ship the work. Operations under a single engagement. No long-term contract. The same model on every line."
           />
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:auto-rows-fr">
             <ServiceCard

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -66,6 +66,7 @@ export function Footer() {
               RevenuePoint implements, operates, and adds intelligence to the CRM, ERP, and AI orchestration growing businesses run on.
             </p>
             <address className="mt-8 not-italic font-mono text-xs text-mute leading-relaxed space-y-1">
+              <p className="text-ink">Three World Financial Center</p>
               <p className="text-ink">200 Vesey Street, 24th Floor</p>
               <p className="text-ink">New York, NY 10281</p>
               <p className="mt-3">


### PR DESCRIPTION
## Summary

Phase 2 PR 3 of 3 (P2 wave) for revenuepoint/revenuepoint.com#10. Final polish on top of #13 (P0 wave, merged 1f9deac) and #14 (P1 wave, merged b8a6500).

**4 files · 10 insertions · 3 deletions.**

## What changed

- **HOME-21** — Homepage *What we do* body: *Implementation in weeks* → *Two-week sprints to ship the work* (locked cadence claim per `lexicon.md` §outcome vocabulary).
- **FNDY-11** — Foundry comparison-table body: *ThoughtSpot costs $140,000/year* → *ThoughtSpot lists at $140,000 a year*; *Foundry starts at $2,500/month* → *Foundry starts at $2,500 a month* (register consistency in body prose; slash construction reads tighter as `a year` / `a month` per `editorial-style.md` §numbers).
- **GTWY-05** — Gateway implementation section heading: *Live in 4 weeks. Here's how.* → italicized *Four-week go-live. Here's how.* (matches the page's italicized-noun mechanic).
- **MICRO-FOOTER-03** — Footer address: adds *Three World Financial Center* line for consistency with `/contact/` per locked `receipts.md` address.

## Skipped

- **SF-TR-04** — `PlaybookWalkthrough` component reviewed; no retired phrases found, no changes needed.
- **BRAND-meta** — `layout.tsx` default metadata already handles the homepage (title template `%s — RevenuePoint` + default `RevenuePoint — CRM + ERP + AI Orchestration` cover the page). Adding explicit per-page metadata would create redundant title doubling. Out of scope for this round.
- **MICRO-NAV-02** — Top-level *Services* label evaluation (deferred XL — post-launch decision per `microcopy.md`).

## Test plan

- [x] **TypeScript typecheck** passes (`npx tsc --noEmit` returns 0)
- [x] **Regex banlist** clean across `src/app/`, `src/components/`, `src/data/`, `src/lib/`
- [ ] **Build** — `npm run build` (run before merge)
- [ ] **Visual QA at `npm run dev`** — homepage *What we do* body, Foundry comparison-table body, Gateway implementation section heading, footer address block
- [ ] **Founder cold-read** — these are tightening edits; quick visual confirm should suffice

## Phase 3 — End-to-end verification (after this PR merges)

Per the plan, after PR 3 merges the verification sweep runs:

- Regex banlist clean on full `src/` (insights blog hits remain — Phase 4 follow-up)
- Voice-fidelity grader ≥80 across the 8-page sample (homepage, foundry, salesforce, sap, gateway, IR, npsp-middleware, contact)
- 7-question pre-flight on flagship pages
- Visual QA desktop + mobile across 25+ in-scope pages
- Founder cold-read sign-off in #10

Refs #10. Closes the P0/P1/P2 implementation arc; Phase 3 verification + Phase 4 cleanup remain.